### PR TITLE
fix: activities must have a username

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ test {
 }
 
 group 'es.sralloza'
-version '1.0.4'
+version '1.0.5'
 mainClassName = 'RunStrava'
 
 repositories {

--- a/src/main/java/mappers/ActivityBuilder.java
+++ b/src/main/java/mappers/ActivityBuilder.java
@@ -60,6 +60,14 @@ public class ActivityBuilder {
             log.debug("Activity is a joined club event, skipping");
             return false;
         }
+
+        // An activity must have at least one username
+        int usernameElements = webElement.findElements(config.getCssSelector("username")).size();
+        if (usernameElements < 1) {
+            log.warn("Found section with {} username elements: {}", usernameElements, webElement.getAttribute("innerHTML"));
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Identify as non-activity anything that doesn't have a username.